### PR TITLE
Add riscv64 architecture

### DIFF
--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -55,6 +55,7 @@ class Launchpad:
         "armhf",
         "i386",
         "ppc64el",
+        "riscv64",
         "s390x",
     ]
 
@@ -296,6 +297,7 @@ class Launchpad:
                 "/+processors/armhf",
                 "/+processors/i386",
                 "/+processors/ppc64el",
+                "/+processors/riscv64",
                 "/+processors/s390x",
             ],
             "store_series": "/+snappy-series/16",

--- a/tests/cassettes/LaunchpadTest.test_04_create_snap.yaml
+++ b/tests/cassettes/LaunchpadTest.test_04_create_snap.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: ws.op=new&owner=%2F%7Ebuild.staging.snapcraft.io&name=57872c9265e7749eb552312d0ac74b79&store_name="new-test-snap"&git_repository_url=https%3A%2F%2Fgithub.com%2Fbuild-staging-snapcraft-io%2Ftest1&git_path=HEAD&auto_build=false&auto_build_archive=%2Fubuntu%2F%2Barchive%2Fprimary&auto_build_pocket=Updates&processors=%2F%2Bprocessors%2Famd64&processors=%2F%2Bprocessors%2Farm64&processors=%2F%2Bprocessors%2Farmhf&processors=%2F%2Bprocessors%2Fi386&processors=%2F%2Bprocessors%2Fppc64el&processors=%2F%2Bprocessors%2Fs390x&store_series=%2F%2Bsnappy-series%2F16
+    body: ws.op=new&owner=%2F%7Ebuild.staging.snapcraft.io&name=57872c9265e7749eb552312d0ac74b79&store_name="new-test-snap"&git_repository_url=https%3A%2F%2Fgithub.com%2Fbuild-staging-snapcraft-io%2Ftest1&git_path=HEAD&auto_build=false&auto_build_archive=%2Fubuntu%2F%2Barchive%2Fprimary&auto_build_pocket=Updates&processors=%2F%2Bprocessors%2Famd64&processors=%2F%2Bprocessors%2Farm64&processors=%2F%2Bprocessors%2Farmhf&processors=%2F%2Bprocessors%2Fi386&processors=%2F%2Bprocessors%2Fppc64el&processors=%2F%2Bprocessors%2Friscv64&processors=%2F%2Bprocessors%2Fs390x&store_series=%2F%2Bsnappy-series%2F16
     headers:
       Accept:
       - application/json

--- a/tests/cassettes/LaunchpadTest.test_05_build_snap.yaml
+++ b/tests/cassettes/LaunchpadTest.test_05_build_snap.yaml
@@ -203,6 +203,38 @@ interactions:
       X-Xss-Protection: [1; mode=block]
     status: {code: 201, message: Created}
 - request:
+    body: ws.op=requestBuild&channels=snapcraft%2Capt&archive=https%3A%2F%2Fapi.launchpad.net%2Fdevel%2Fubuntu%2F%2Barchive%2Fprimary&pocket=Updates&distro_arch_series=%2Fubuntu%2Fxenial%2Friscv64
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['186']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.22.0]
+    method: POST
+    uri: https://api.launchpad.net/devel/~build.staging.snapcraft.io/+snap/492e3ccd1da99dc98226e483d55ce16b
+  response:
+    body: {string: ''}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['0']
+      Content-Security-Policy: [frame-ancestors 'self';]
+      Content-Type: [text/plain;charset=utf-8]
+      Date: ['Fri, 21 Feb 2020 09:27:57 GMT']
+      Keep-Alive: ['timeout=60, max=94']
+      Location: ['https://api.launchpad.net/devel/~build.staging.snapcraft.io/+snap/492e3ccd1da99dc98226e483d55ce16b/+build/843225']
+      Server: [zope.server.http (HTTP)]
+      Strict-Transport-Security: [max-age=15552000]
+      Vary: [Accept]
+      X-Content-Type-Options: [nosniff]
+      X-Content-Type-Warning: [guessed from content]
+      X-Frame-Options: [SAMEORIGIN]
+      X-Launchpad-Revision: [19413b719a8df7423ab1390528edadce9e0e4aca]
+      X-Lazr-Notifications: ['[]']
+      X-Powered-By: ['Zope (www.zope.org), Python (www.python.org)']
+      X-Xss-Protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
     body: ws.op=requestBuild&channels=snapcraft%2Capt&archive=https%3A%2F%2Fapi.launchpad.net%2Fdevel%2Fubuntu%2F%2Barchive%2Fprimary&pocket=Updates&distro_arch_series=%2Fubuntu%2Fxenial%2Fs390x
     headers:
       Accept: [application/json]
@@ -221,8 +253,8 @@ interactions:
       Content-Security-Policy: [frame-ancestors 'self';]
       Content-Type: [text/plain;charset=utf-8]
       Date: ['Fri, 21 Feb 2020 09:27:58 GMT']
-      Keep-Alive: ['timeout=60, max=94']
-      Location: ['https://api.launchpad.net/devel/~build.staging.snapcraft.io/+snap/492e3ccd1da99dc98226e483d55ce16b/+build/843225']
+      Keep-Alive: ['timeout=60, max=93']
+      Location: ['https://api.launchpad.net/devel/~build.staging.snapcraft.io/+snap/492e3ccd1da99dc98226e483d55ce16b/+build/843226']
       Server: [zope.server.http (HTTP)]
       Strict-Transport-Security: [max-age=15552000]
       Vary: [Accept]

--- a/tests/cassettes/LaunchpadTest.test_06_get_builders_status.yaml
+++ b/tests/cassettes/LaunchpadTest.test_06_get_builders_status.yaml
@@ -311,6 +311,56 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Friscv64&virtualized=true
+  response:
+    body:
+      string: '60'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:26 GMT
+      Keep-Alive:
+      - timeout=60, max=94
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
     uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Fs390x&virtualized=true
   response:
     body:
@@ -327,7 +377,7 @@ interactions:
       Date:
       - Thu, 21 May 2020 09:21:26 GMT
       Keep-Alive:
-      - timeout=60, max=94
+      - timeout=60, max=93
       Server:
       - zope.server.http (HTTP)
       Strict-Transport-Security:


### PR DESCRIPTION
This architecture is now virtualized and unrestricted in Launchpad, so snapcraft.io can support it.